### PR TITLE
Fix emails not sent after upgrade from v3.2 (v3.3.1)

### DIFF
--- a/includes/OverrideEmailSender.php
+++ b/includes/OverrideEmailSender.php
@@ -46,7 +46,8 @@ class OverrideEmailSender {
         }
 
         if ( $is_forced_email || $wp_from_email === $default_email ) {
-            return sanitize_email( $custom_from_email );
+            $clean = sanitize_email( $custom_from_email );
+            return '' !== $clean ? $clean : $wp_from_email;
         }
 
         return $wp_from_email;

--- a/includes/Upgrader.php
+++ b/includes/Upgrader.php
@@ -44,16 +44,20 @@ class Upgrader {
             $this->migrate_to_3_3();
         }
 
+        if ( version_compare( $stored, '3.3.1', '<' ) ) {
+            $this->migrate_to_3_3_1();
+        }
+
         update_option( self::DB_VERSION_OPTION, $current );
     }
 
     /**
      * Copy the legacy standalone sender options into the unified settings
-     * option introduced in 3.3.
+     * option introduced in 3.3, and restore v3.2 "always override From"
+     * behaviour by enabling both force flags.
      *
      * Idempotent: reruns are safe because the outer version gate prevents
-     * re-entry, and values already present in the new option are never
-     * overwritten.
+     * re-entry.
      *
      * The legacy options are intentionally left in place as a safety net.
      * They can be removed in a later release once the migration has had
@@ -62,26 +66,50 @@ class Upgrader {
      * @return void
      */
     private function migrate_to_3_3() {
-        $legacy_name  = get_option( 'wpces_email_sender_name', '' );
-        $legacy_email = get_option( 'wpces_sender_email_address', '' );
-
-        if ( '' === $legacy_name && '' === $legacy_email ) {
-            return;
-        }
-
         $settings = get_option( self::SETTINGS_OPTION, array() );
 
         if ( ! is_array( $settings ) ) {
             $settings = array();
         }
 
-        if ( empty( $settings['wp_change_email_sender_name'] ) && '' !== $legacy_name ) {
+        // Preserve v3.2 behaviour: it always overrode From for every wp_mail() call.
+        $settings['force_from_name']  = true;
+        $settings['force_from_email'] = true;
+
+        $legacy_name  = get_option( 'wpces_email_sender_name', '' );
+        $legacy_email = get_option( 'wpces_sender_email_address', '' );
+
+        if ( '' !== $legacy_name && empty( $settings['wp_change_email_sender_name'] ) ) {
             $settings['wp_change_email_sender_name'] = sanitize_text_field( $legacy_name );
         }
 
-        if ( empty( $settings['wp_change_email_sender_email_address'] ) && '' !== $legacy_email ) {
+        if ( '' !== $legacy_email && empty( $settings['wp_change_email_sender_email_address'] ) ) {
             $settings['wp_change_email_sender_email_address'] = sanitize_email( $legacy_email );
         }
+
+        update_option( self::SETTINGS_OPTION, $settings );
+    }
+
+    /**
+     * Force-enable both From overrides on upgrade to 3.3.1.
+     *
+     * Covers v3.3.0 → v3.3.1 installs that already migrated away from the
+     * legacy options but landed with force_* defaulting to false, causing
+     * SMTP relays in strict-sender mode to reject mail from other plugins.
+     *
+     * Idempotent via the outer version gate in maybe_upgrade().
+     *
+     * @return void
+     */
+    private function migrate_to_3_3_1() {
+        $settings = get_option( self::SETTINGS_OPTION, array() );
+
+        if ( ! is_array( $settings ) ) {
+            $settings = array();
+        }
+
+        $settings['force_from_name']  = true;
+        $settings['force_from_email'] = true;
 
         update_option( self::SETTINGS_OPTION, $settings );
     }

--- a/includes/WpChangeEmailSender.php
+++ b/includes/WpChangeEmailSender.php
@@ -14,7 +14,7 @@ final class WpChangeEmailSender {
      *
      * @var string
      */
-    public $version = '3.3.0';
+    public $version = '3.3.1';
 
     /**
      * Instance of self

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-change-email-sender",
-	"version": "3.3.0",
+	"version": "3.3.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-change-email-sender",
-			"version": "3.3.0",
+			"version": "3.3.1",
 			"license": "GPLv2 or later",
 			"dependencies": {
 				"@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-change-email-sender",
-	"version": "3.3.0",
+	"version": "3.3.1",
 	"description": "This plugin which allows you to change WordPress default mail sender name and email address easily.",
 	"author": "Aminur Islam",
 	"license": "GPLv2 or later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.buymeacoffee.com/aiarnob
 Tags: wp change email sender, wp change default email sender, wordpress default email sender change, wp default email change, wp default email sender name change
 Requires at least: 5.8
 Tested up to: 6.9
-Stable tag: 3.3.0
+Stable tag: 3.3.1
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -69,6 +69,10 @@ If you find this plugin useful, consider supporting its development through a [d
 
 
 == Changelog ==
+
+= 3.3.1 =
+* Fix: After upgrading from 3.2, emails sent by other plugins (e.g. WooCommerce, contact forms) could be rejected by SMTP relays because the configured sender was not being applied. Restored 3.2 behaviour by enabling "Force From Name" and "Force From Email" automatically on upgrade. You can change these toggles from the plugin's settings page if you want other plugins' sender addresses to be preserved.
+* Hardening: Fall back to the original sender if the saved sender email becomes empty after sanitisation, preventing silent send failures.
 
 = 3.3.0 =
 * **Modernized Admin Dashboard**: Rebuilt the settings page as a fast, single-page React application with a premium native-like design.

--- a/wp-change-email-sender.php
+++ b/wp-change-email-sender.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Change Email Sender
  * Plugin URI:  https://wordpress.org/plugins/wp-change-email-sender/
  * Description: This plugin which allows you to change WordPress default mail sender name and email address easily.
- * Version: 3.3.0
+ * Version: 3.3.1
  * Author: Aminur Islam
  * Author URI: https://github.com/aminurislamarnob/
  * Text Domain: wp-change-email-sender


### PR DESCRIPTION
Force-enable force_from_email and force_from_name on upgrade to restore v3.2 "always override From" behaviour. Both the v3.2 → v3.3.1 path (migrate_to_3_3) and the v3.3.0 → v3.3.1 path (new migrate_to_3_3_1) converge with both flags set to true so SMTP relays with strict-sender enforcement stop rejecting mail dispatched by other plugins.

Also fall back to the original sender when sanitize_email() empties the stored value, preventing silent wp_mail() failures on malformed input.

Refs aminurislamarnob/wp-change-email-sender#11

### PR Todo
Describe your PR's. It could be a checklist or description

# PR Guidelines

### Features:

* [ ] My code satisfies feature requirements.
* [ ] I update README file to track the core file changes of the dependant plugins.
* [ ] I use localized text everywhere.

### Coding Standards:
* [ ] My code is readable.
* [ ] My code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
* [ ] My code has proper inline documentation.
* [ ] My code follows KISS: Keep it simple, Sweetie (not stupid!).
* [ ] My code follows DRY: Don't Repeat Yourself.
* [ ] I check Grammar and spelling errors.
* [ ] I use [Semantic HTML5](https://www.semrush.com/blog/semantic-html5-guide/#types-of-html-semantic-tags).
* [ ] Padding, margin, font size, font family, adn etc are same for the same HTML component.

### Code Security:
* [ ] My code use [nonce](https://developer.wordpress.org/apis/security/nonces/) to  protect against several types of attacks including CSRF .
* [ ] User data is properly [sanitized](https://developer.wordpress.org/apis/security/sanitizing/).
* [ ] User data is properly [validated](https://developer.wordpress.org/apis/security/data-validation/) e.i. a field is required or not.
* [ ] Data is properly [escaped](https://developer.wordpress.org/apis/security/escaping/) to prevent malformed HTML or script tags.
* [ ] I check  user's [roles and permission](https://developer.wordpress.org/apis/security/user-roles-and-capabilities/) properly.
* [ ] I use [prepare function](https://developer.wordpress.org/reference/classes/wpdb/prepare/) for SQL to prevent the [SQL injection](https://developer.wordpress.org/apis/security/common-vulnerabilities/#sql-injection).
* [ ] Use the  [Plugin Check](https://wordpress.org/plugins/plugin-check/) plugin to check your plugin's coding standards, securities, etc.